### PR TITLE
Extended configuration to allow to set the hostname of the smtp client.

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -7,6 +7,8 @@ const (
 	DefaultOnlyRecipients = false
 	// DefaultSkipVerify controls wether to skip SSL verification for the SMTP server
 	DefaultSkipVerify = false
+  // DefaultClientHostname is the client hostname used in the HELO command sent to the SMTP server
+  DefaultClientHostname = "localhost"
 )
 
 // DefaultSubject is the default subject template to use for the email

--- a/main.go
+++ b/main.go
@@ -84,6 +84,13 @@ func main() {
 			Usage:  "attachment filename(s)",
 			EnvVar: "PLUGIN_ATTACHMENTS",
 		},
+    cli.StringFlag{
+			Name:   "clienthostname",
+			Value:  DefaultClientHostname,
+			Usage:  "smtp client hostname",
+			EnvVar: "EMAIL_CLIENTHOSTNAME,PLUGIN_CLIENTHOSTNAME",
+		},
+		
 
 		// Drone environment
 		// Repo
@@ -381,6 +388,7 @@ func run(c *cli.Context) error {
 			Body:           c.String("template.body"),
 			Attachment:     c.String("attachment"),
 			Attachments:    c.StringSlice("attachments"),
+			ClientHostname:   c.String("clienthostname"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -91,6 +91,7 @@ type (
 		Body           string
 		Attachment     string
 		Attachments    []string
+		ClientHostname   string
 	}
 
 	Plugin struct {
@@ -133,6 +134,7 @@ func (p Plugin) Exec() error {
 	if p.Config.SkipVerify {
 		dialer.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 	}
+  dialer.LocalName = p.Config.ClientHostname
 
 	closer, err := dialer.Dial()
 	if err != nil {


### PR DESCRIPTION
This is my porposal to implement #33:

The value  configured by 'clienthostname' is used by the gomail client
as hostname in the HELO command.