### PR TITLE
Update Go and Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.8-alpine as builder
+FROM golang:1.14-alpine as builder
 
 WORKDIR /go/src/drone-email
 COPY . .
 
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build
 
-FROM alpine:3.4
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Fixes #36 

- Updated Go to 1.14
- Updated Alpine to 3.11

Not sure what to do about the [armhf build](https://github.com/Drillster/drone-email/blob/master/Dockerfile.armhf). The Docker container [armhfbuild/alpine](https://hub.docker.com/r/armhfbuild/alpine) hasn't been updated in 4yrs.

I think we can use [arm32v7/alpine](https://hub.docker.com/r/arm32v7/alpine/), but not 100% sure. If you agree, I can open a PR for that as well.