### PR TITLE
Use /run/drone/env as default PLUGIN_ENV_FILE, overwrite env vars with it

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,8 +10,12 @@ import (
 
 func main() {
 	// Load env-file if it exists first
-	if env := os.Getenv("PLUGIN_ENV_FILE"); env != "" {
-		godotenv.Load(env)
+	envFile, envFileSet := os.LookupEnv("PLUGIN_ENV_FILE")
+	if !envFileSet {
+		envFile = "/run/drone/env"
+	}
+	if _, err := os.Stat(envFile); err == nil {
+		godotenv.Overload(envFile)
 	}
 
 	app := cli.NewApp()
@@ -84,13 +88,12 @@ func main() {
 			Usage:  "attachment filename(s)",
 			EnvVar: "PLUGIN_ATTACHMENTS",
 		},
-    cli.StringFlag{
+		cli.StringFlag{
 			Name:   "clienthostname",
 			Value:  DefaultClientHostname,
 			Usage:  "smtp client hostname",
 			EnvVar: "EMAIL_CLIENTHOSTNAME,PLUGIN_CLIENTHOSTNAME",
 		},
-		
 
 		// Drone environment
 		// Repo
@@ -388,7 +391,7 @@ func run(c *cli.Context) error {
 			Body:           c.String("template.body"),
 			Attachment:     c.String("attachment"),
 			Attachments:    c.StringSlice("attachments"),
-			ClientHostname:   c.String("clienthostname"),
+			ClientHostname: c.String("clienthostname"),
 		},
 	}
 


### PR DESCRIPTION
DISCLAIMER: first time ever touching Go code, so feel free to request any updates to styling or the approach itself, or even do it yourself (I have enabled edits by maintainers).

It is required for the plugin to work correctly with Kubernetes runner, where
environment variables are created before the pipeline is finished and thus
initial DRONE_BUILD_STATUS is always "success".

Related discourse topic:

https://discourse.drone.io/t/drone-build-status-always-success-in-kubernetes/6627/2

Similar workaround in drone-slack:

https://github.com/drone-plugins/drone-slack/blob/59d3676b1cb7dbbdd9ca4b677570cd510ed8929a/main.go#L187-L189