### PR TITLE
Update Arm Dockerfile

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine as builder
+FROM golang:1.15-alpine as builder
 
 WORKDIR /go/src/drone-email
 COPY . .


### PR DESCRIPTION
After several tries, the arm dockerfile is not working at all, and there is an error of the binary.
only change to golang 1.15 solve it