### PR TITLE
upgrade from alpine linux 3.11 to 3.14 for newer SSL root certs (old …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build
 
-FROM alpine:3.11
+FROM alpine:3.14
 
 RUN apk add --no-cache ca-certificates
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,7 +5,7 @@ COPY . .
 
 RUN GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build
 
-FROM alpine:3.11
+FROM alpine:3.14
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
…certs were now expired for some lets encrypt certs)

for your convenience 

addressing #54 