### PR TITLE
Extended from configuration to support utf8 name

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -3,7 +3,8 @@ Use the Email plugin for sending build status notifications via email.
 ## Config
 You can configure the plugin using the following parameters:
 
-* **from** - Send notifications from this address
+* **from.address** - Send notifications from this address
+* **from.name** - Notifications sender name
 * **host** - SMTP server host
 * **port** - SMTP server port, defaults to `587`
 * **username** - SMTP username
@@ -29,7 +30,8 @@ steps:
   - name: notify
     image: drillster/drone-email
     settings:
-      from: noreply@github.com
+      from.address: noreply@github.com
+      from.name: John Smith
       host: smtp.mailgun.org
       username: octocat
       password: 12345
@@ -45,7 +47,7 @@ steps:
   - name: notify:
     image: drillster/drone-email
     settings:
-      from: noreply@github.com
+      from.address: noreply@github.com
       host: smtp.mailgun.org
 +     username:
 +       from_secret: email_username
@@ -91,7 +93,7 @@ steps:
   - name: notify
     image: drillster/drone-email
     settings:
-      from: noreply@github.com
+      from.address: noreply@github.com
       host: smtp.mailgun.org
       username: octocat
       password: 12345

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Execute from the working directory:
 
 ```sh
 docker run --rm \
-  -e PLUGIN_FROM=drone@test.test \
+  -e PLUGIN_FROM_ADDRESS=drone@test.test \
+  -e PLUGIN_FROM_NAME="John Smith" \
   -e PLUGIN_HOST=smtp.test.test \
   -e PLUGIN_USERNAME=drone \
   -e PLUGIN_PASSWORD=test \

--- a/main.go
+++ b/main.go
@@ -31,6 +31,16 @@ func main() {
 			EnvVar: "PLUGIN_FROM",
 		},
 		cli.StringFlag{
+			Name:   "from.address",
+			Usage:  "from address",
+			EnvVar: "PLUGIN_FROM_ADDRESS",
+		},
+		cli.StringFlag{
+			Name:   "from.name",
+			Usage:  "from name",
+			EnvVar: "PLUGIN_FROM_NAME",
+		},
+		cli.StringFlag{
 			Name:   "host",
 			Usage:  "smtp host",
 			EnvVar: "EMAIL_HOST,PLUGIN_HOST",
@@ -325,6 +335,12 @@ func main() {
 }
 
 func run(c *cli.Context) error {
+
+	var fromAddress string = c.String("from")
+	if fromAddress == "" {
+		fromAddress = c.String("from.address")
+	}
+
 	plugin := Plugin{
 		Repo: Repo{
 			FullName: c.String("repo.fullName"),
@@ -384,7 +400,8 @@ func run(c *cli.Context) error {
 		PullRequest: c.Int("pullRequest"),
 		DeployTo:    c.String("deployTo"),
 		Config: Config{
-			From:           c.String("from"),
+			FromAddress:    fromAddress,
+			FromName:       c.String("from.name"),
 			Host:           c.String("host"),
 			Port:           c.Int("port"),
 			Username:       c.String("username"),

--- a/plugin.go
+++ b/plugin.go
@@ -81,7 +81,8 @@ type (
 	}
 
 	Config struct {
-		From           string
+		FromAddress    string
+		FromName       string
 		Host           string
 		Port           int
 		Username       string
@@ -212,7 +213,7 @@ func (p Plugin) Exec() error {
 		if len(recipient) == 0 {
 			continue
 		}
-		message.SetHeader("From", p.Config.From)
+		message.SetAddressHeader("From", p.Config.FromAddress, p.Config.FromName)
 		message.SetAddressHeader("To", recipient, "")
 		message.SetHeader("Subject", subject)
 		message.AddAlternative("text/plain", plainBody)


### PR DESCRIPTION
Better support fromName that need encoding.

```
docker run --rm \
  -e PLUGIN_FROM_ADDRESS=drone@test.test \
  -e PLUGIN_FROM_NAME='Лев Николаевич Толстой' \
  -e PLUGIN_HOST=smtp.test.test \
  -e PLUGIN_USERNAME=drone \
  -e PLUGIN_PASSWORD=test \
  -e DRONE_REPO_OWNER=octocat \
  -e DRONE_REPO_NAME=hello-world \
  -e DRONE_COMMIT_SHA=7fd1a60b01f91b314f59955a4e4d4e80d8edf11d \
  -e DRONE_COMMIT_BRANCH=master \
  -e DRONE_COMMIT_AUTHOR=octocat \
  -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@test.test \
  -e DRONE_BUILD_NUMBER=1 \
  -e DRONE_BUILD_STATUS=success \
  -e DRONE_BUILD_LINK=http://github.com/octocat/hello-world \
  -e DRONE_COMMIT_MESSAGE="Hello world!" \
  -v $(pwd):$(pwd) \
  -w $(pwd) \
  drillster/drone-email
```