### PR TITLE
map commit.author.name to DRONE_COMMIT_AUTHOR_NAME

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "commit.author.name",
 			Usage:  "git author name",
-			EnvVar: "DRONE_COMMIT_AUTHOR",
+			EnvVar: "DRONE_COMMIT_AUTHOR,DRONE_COMMIT_AUTHOR_NAME",
 		},
 		cli.StringFlag{
 			Name:   "commit.author.email",


### PR DESCRIPTION
I'm fairly new to Drone and might missing something, but in my test pipeline the currently mapped DRONE_COMMIT_AUTHOR is not set, but DRONE_COMMIT_AUTHOR_NAME is and therefore i've quickly added the suffix..