### PR TITLE
verbosity and default sender name and email address

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,11 @@ func main() {
 	app.Version = "2.0.2"
 	app.Flags = []cli.Flag{
 		// Plugin environment
+		cli.BoolFlag{
+			Name:   "verbose",
+			Usage:  "set verbosity",
+			EnvVar: "PLUGIN_VERBOSE",
+		},
 		cli.StringFlag{
 			Name:   "from",
 			Usage:  "from address",
@@ -405,6 +410,7 @@ func run(c *cli.Context) error {
 		PullRequest: c.Int("pullRequest"),
 		DeployTo:    c.String("deployTo"),
 		Config: Config{
+			Verbose:        c.Bool("verbose"),
 			FromAddress:    fromAddress,
 			FromName:       c.String("from.name"),
 			Host:           c.String("host"),

--- a/plugin.go
+++ b/plugin.go
@@ -145,7 +145,7 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Config.Verbose {
-		log.Infof ("Host [%s], Port [%d], Username [%s] Password[%s]", p.Config.Host, p.Config.Port, p.Config.Username, p.Config.Password)
+		log.Infof ("Host [%s], Port [%d], Username [%s]", p.Config.Host, p.Config.Port, p.Config.Username);
 	}
 
 	if p.Config.Username == "" && p.Config.Password == "" {

--- a/plugin.go
+++ b/plugin.go
@@ -220,7 +220,21 @@ func (p Plugin) Exec() error {
 		if len(recipient) == 0 {
 			continue
 		}
-		message.SetAddressHeader("From", p.Config.FromAddress, p.Config.FromName)
+
+		from_address := p.Config.FromAddress
+		from_name := p.Config.FromName
+		if from_address == "" {
+			from_address = p.Commit.Author.Email
+			if from_address == "" {
+				from_address = recipient
+			}
+
+			if from_name == "" { // only if from_address is blank as well
+				from_name = p.Commit.Author.Name
+			}
+		}
+
+		message.SetAddressHeader("From", from_address, from_name)
 		message.SetAddressHeader("To", recipient, "")
 		message.SetHeader("Subject", subject)
 		message.AddAlternative("text/plain", plainBody)

--- a/plugin.go
+++ b/plugin.go
@@ -81,6 +81,7 @@ type (
 	}
 
 	Config struct {
+		Verbose        bool
 		FromAddress    string
 		FromName       string
 		Host           string
@@ -141,6 +142,10 @@ func (p Plugin) Exec() error {
 		} else {
 			log.Errorf("Could not open RecipientsFile %s: %v", p.Config.RecipientsFile, err)
 		}
+	}
+
+	if p.Config.Verbose {
+		log.Infof ("Host [%s], Port [%d], Username [%s] Password[%s]", p.Config.Host, p.Config.Port, p.Config.Username, p.Config.Password)
 	}
 
 	if p.Config.Username == "" && p.Config.Password == "" {
@@ -232,6 +237,10 @@ func (p Plugin) Exec() error {
 			if from_name == "" { // only if from_address is blank as well
 				from_name = p.Commit.Author.Name
 			}
+		}
+
+		if p.Config.Verbose {
+			log.Infof ("Recipient [%s] From [%s <%s>]", recipient, from_name, from_address)
 		}
 
 		message.SetAddressHeader("From", from_address, from_name)


### PR DESCRIPTION
I've added a new option `verbose` or `PLUGIN_VERBOSE` to print some informational text to make troubleshooting easier.

To minimize the amount of configuration, I've changed the code to use the committer information when the sender's email  and  name (`from.email`, `from.name`) are not set.

Thank you.